### PR TITLE
Allow passing in SSA uses for debugging

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -5,7 +5,7 @@ abstract type TransformationState{T} end
 abstract type AbstractTearingState{T} <: TransformationState{T} end
 
 struct SelectedState end
-BipartiteGraphs.overview_label(::Type{SelectedState}) = ('∫', " Seleced State", :cyan)
+BipartiteGraphs.overview_label(::Type{SelectedState}) = ('∫', " Selected State", :cyan)
 
 function linear_subsys_adjmat! end
 function eq_derivative! end


### PR DESCRIPTION
This introduces a mechanism to associate SSA uses with equations or variables, to be used in a `%` column for each.