### PR TITLE
fix: allow multiple observables to solve from the same inline linsolve index

### DIFF
--- a/lib/ModelingToolkitTearing/src/ModelingToolkitTearing.jl
+++ b/lib/ModelingToolkitTearing/src/ModelingToolkitTearing.jl
@@ -159,8 +159,8 @@ function MTKBase.unhack_system(sys::System)
     subst = SU.Substituter{false}(additional_subs, SU.default_substitute_filter)
     obseqs = obseqs[obs_mask]
     map!(subst, obseqs, obseqs)
-    map!(subst, additional_eqs, additional_eqs)
     append!(eqs, additional_eqs)
+    map!(subst, eqs, eqs)
 
     if sched isa MTKBase.Schedule
         map!(subst, values(sched.dummy_sub))
@@ -190,14 +190,7 @@ function populate_inline_scc_map!(
     is_ldiv || return
     len = length(ldiv)
     buffer = get!(() -> zeros(Int, len), inline_linear_scc_map, ldiv)
-    if !iszero(buffer[idx])
-        is_diffeq && return
-        throw(ArgumentError("""
-        Found multiple inline linear solves solving the same variable. \
-        This should not be possible. Please open an issue in \
-        `ModelingToolkit.jl` with an MWE.
-        """))
-    end
+    iszero(buffer[idx]) || return
     buffer[idx] = ifelse(is_diffeq, -eq_i, eq_i)
 end
 


### PR DESCRIPTION
The situation is that `D(x)` part of an inline linear SCC, so it turns into `D(x) ~ linsolve(..)[i]` and this goes into `total_sub`. Then, two observed equations are of the form

```julia
y ~ D(D(foo))
z ~ D(D(foo))
```

Where `D(D(foo))` via `total_sub` resolves to `D(x)` and then `linsolve(..)[i]`. So multiple observed variables can be obtained from the same inline linear solve. This PR modifies `unhack_system` to handle that case.

The reproducer is from Dyad and is not something I'm able to MWE.