### PR TITLE
Bump ModelingToolkitTearing SciMLBase compat to include v3

### DIFF
--- a/lib/ModelingToolkitTearing/Project.toml
+++ b/lib/ModelingToolkitTearing/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitTearing"
 uuid = "6bb917b9-1269-42b9-9f7c-b0dca72083ab"
-version = "1.12.3"
+version = "1.13.0"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
 
 [deps]
@@ -34,7 +34,7 @@ ModelingToolkitBase = "1.23"
 Moshi = "0.3"
 OffsetArrays = "1"
 OrderedCollections = "1.8.1"
-SciMLBase = "2.108"
+SciMLBase = "2.108, 3"
 Setfield = "0.7, 0.8, 1"
 SparseArrays = "1"
 StateSelection = "1.9"


### PR DESCRIPTION
## Summary

Widen `lib/ModelingToolkitTearing/Project.toml`'s `SciMLBase = "2.108"` → `"2.108, 3"` so ModelingToolkitTearing resolves alongside SciMLBase v3 (shipping as part of the OrdinaryDiffEq v7 release line). Bumps `ModelingToolkitTearing` 1.12.3 → 1.13.0.

`StateSelection` (the root package) has no `SciMLBase` or `DiffEqBase` dependency and is unchanged.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch) the `test (ModelingToolkit, …)` matrix fails at resolve time. Working up the stack, the final blocker (after the upstream compat bumps in SciML/DiffEqCallbacks.jl#303, SciML/DiffEqNoiseProcess.jl#271, SciML/DiffEqProblemLibrary.jl#182, SciML/JumpProcesses.jl#580, and SciML/ModelingToolkit.jl#4467 are applied) is:

```
Unsatisfiable requirements detected for package ModelingToolkitTearing [6bb917b9]:
 ModelingToolkitTearing [6bb917b9] log:
 ├─possible versions are: 1.0.0 - 1.12.3 or uninstalled
 └─restricted by compatibility requirements with SciMLBase [0bca4576] to versions: uninstalled — no versions left
   └─SciMLBase [0bca4576] log:
     ├─possible versions are: 1.0.0 - 3.3.0 or uninstalled
     └─restricted to versions 3 by StochasticDiffEqLowOrder [d15fe365]
```

`lib/ModelingToolkitTearing/Project.toml` had `SciMLBase = "2.108"`, excluding v3. This PR widens that cap.

## Why this is source-level safe

Grepped `lib/ModelingToolkitTearing/src/` for every symbol removed in the SciMLBase v3 breaking notes (`u_modified!`, `has_destats`, `sol.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`, `sol.x`/`sol.minimizer`/`sol.minimum`). **Zero matches.**

The only SciMLBase API surface MTKTearing touches:

- `SciMLBase.AbstractClock`, `SciMLBase.ContinuousClock(…)`, `SciMLBase.PeriodicClock(dt)` — clock-domain types in `clock_inference/`. Untouched by v3.
- `SciMLBase.LinearProblem` — untouched by v3.

None of these are on the v3 removal or rename list.

## Verified end-to-end

On Julia 1.11, with this branch's `lib/ModelingToolkitTearing` dev'd alongside `lib/DiffEqBase` v7.0.0, `lib/OrdinaryDiffEqCore` v4.0.0, the DiffEqCallbacks / DiffEqNoiseProcess / ODEProblemLibrary / JumpProcesses / MTK / MTKBase compat-widened branch versions, and the full OrdinaryDiffEq monorepo sublib set:

- Resolver: clean.
- Precompile: clean (MTK 11.22.0, MTKBase 1.31.0, MTKTearing 1.13.0 all load on SciMLBase v3).
- Build + solve:
  ```julia
  using ModelingToolkit, OrdinaryDiffEqTsit5
  using ModelingToolkit: t_nounits as t, D_nounits as D
  @parameters k; @variables x(t)
  @mtkcompile sys = System([D(x) ~ -k*x], t)
  prob = ODEProblem(sys, [x => 1.0, k => 0.5], (0.0, 10.0))
  sol = solve(prob, Tsit5())
  # sol.u[end] == [0.0067385401…] vs analytical exp(-5) == 0.0067379469… (3e-7 agreement)
  ```

## Test plan

- [x] Source grep for every v3-removed symbol — clean.
- [x] End-to-end resolve + precompile + `@mtkcompile` + `solve` with the full v7 stack dev'd in.
- [ ] CI on this PR (against the currently-registered SciMLBase 2.x line; source unchanged — expected green).
- [ ] OrdinaryDiffEq.jl#3488 `test (ModelingToolkit, …)` once this is registered and the upstream SciML-side bumps are registered.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>