### PR TITLE
fix: remove unnecessary `invview` in `rm_eqs_vars!`

### DIFF
--- a/lib/ModelingToolkitTearing/test/runtests.jl
+++ b/lib/ModelingToolkitTearing/test/runtests.jl
@@ -208,3 +208,15 @@ end
     @test findfirst(isequal(y), ts.fullvars) !== nothing
     @test !any(eq -> isequal(eq.lhs, y), ts.additional_observed)
 end
+
+@testset "`rm_eqs_vars!` does not require calling `complete`" begin
+    @variables x(t) y(t)
+    @named sys = System([D(x) ~ 2x + 1, D(y) ~ 2y + 1], t)
+    ts = TearingState(sys)
+    xidx = findfirst(isequal(x), ts.fullvars)::Int
+    dxidx = ts.structure.var_to_diff[xidx]::Int
+    eqidx = only(𝑑neighbors(ts.structure.graph, dxidx))::Int
+    StateSelection.rm_eqs_vars!(ts, [eqidx], [xidx, dxidx])
+    @test length(equations(ts)) == 1
+    @test length(ts.fullvars) == 2
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -237,7 +237,6 @@ function default_rm_eqs_vars!(
     old_to_new_eq, n_new_eqs = get_old_to_new_idxs(nsrcs(graph), eqs_to_rm)
     old_to_new_var, n_new_vars = get_old_to_new_idxs(ndsts(graph), vars_to_rm)
 
-    diff_to_var = invview(var_to_diff)
     new_graph = BipartiteGraph(n_new_eqs, n_new_vars)
     if solvable_graph !== nothing
         new_solvable_graph = BipartiteGraph(n_new_eqs, n_new_vars)


### PR DESCRIPTION
This allows `rm_eqs_vars!` to be called without having to run `complete!(ts.structure)`