### PR TITLE
fix: drop equations from `scc_eqs` whose matched variable is outside the SCC

### DIFF
--- a/lib/ModelingToolkitTearing/Project.toml
+++ b/lib/ModelingToolkitTearing/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelingToolkitTearing"
 uuid = "6bb917b9-1269-42b9-9f7c-b0dca72083ab"
-version = "1.13.5"
+version = "1.13.6"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com>"]
 
 [deps]

--- a/lib/ModelingToolkitTearing/src/reassemble.jl
+++ b/lib/ModelingToolkitTearing/src/reassemble.jl
@@ -702,6 +702,19 @@ function get_sorted_scc(
                setdiff(scc_eqs, scc_solved_eqs)]
     # the variables of the SCC are obtained by inverse mapping the sorted equations
     # and appending the rest
+    # Drop equations whose matched variable in `eq_var_matching` (= inverse of the regular
+    # var↔eq matching) is an Int but is outside this SCC. Such an entry indicates that
+    # the SCC pulled in an equation through `full_var_eq_matching[v]` for some `v ∈ scc`
+    # whose forward-matched eq is also matched to a different variable elsewhere
+    # (e.g. via stale dummy-derivative bookkeeping). Including such an eq in this SCC's
+    # eq list lets `generate_system_equations!` push the same state-variable index into
+    # `var_ordering` from two different SCCs, which trips the dup assertion at
+    # `reassemble.jl:499` ("Tearing internal error: lowering DAE into semi-implicit ODE failed!").
+    scc_set = Set(scc)
+    filter!(e -> begin
+        v = eq_var_matching[e]
+        !(v isa Int) || v in scc_set
+    end, scc_eqs)
     scc_vars = Int[]
     for e in scc_eqs
         v = eq_var_matching[e]


### PR DESCRIPTION
## Summary

Fixes the "Tearing internal error: lowering DAE into semi-implicit ODE failed!" thrown at `reassemble.jl:499` for systems where the dummy-derivative pass leaves stale entries in `full_var_eq_matching` that cause `get_sorted_scc` to pull equations into an SCC's `scc_eqs` whose `eq_var_matching` value points at a variable outside that SCC. When this happens, two distinct SCCs end up emitting differential equations for the same state-variable index (via `push!(var_ordering, diff_to_var[iv])`), tripping the duplicate-state-var assertion.

The fix filters `scc_eqs` in `get_sorted_scc` to keep only equations whose matched variable is either `Unassigned` or inside the SCC. This drops the spurious cross-SCC overlap without affecting well-formed systems.

## Root cause

In `generate_system_equations!`, `var_ordering` is filled from two push sites:
- `reassemble.jl:460` (linear-SCC inline path): `push!(var_ordering, ∫iv)` with `∫iv = diff_to_var[iv]`
- `reassemble.jl:837` (general `codegen_equation!` derivative-variable branch): `push!(var_ordering, diff_to_var[iv])`

For a duplicate to occur in `var_ordering[is_diff_eq]`, two distinct matched `iv`s must satisfy `diff_to_var[iv₁] == diff_to_var[iv₂]`. In the failing case this happens because the same `iv = D(angles[2])` is processed twice — once in a singleton SCC matched to the joint's `der_angles[2] ~ D(angles[2])` equation, and once again in a separate (large, linsol-able) SCC whose `vscc` was populated by `get_sorted_scc` pulling in that joint equation through `full_var_eq_matching[v]` for some `v` in the larger SCC's `scc` list.

Concretely, with the rolling-wheel reproducer below, `get_sorted_scc` produces:

- `scc = [1, 47, 8, 29, 45, 69, 71, 72, 73, 74, 75, 76, 138, …]` (24 entries, no `2`)
- `scc_eqs(final)` of size 25 including `eq 14`
- `eq_var_matching[14] = 2`, so `scc_vars` ends up with `2` injected at position 17 even though `2 ∉ scc`

The big SCC and the singleton SCC for var `2` then both push `diff_to_var[2] = 20` into `var_ordering`.

## Reproducer

Repo: `JuliaComputing/MultibodyComponents.jl`, branch `rolling_wheel`, HEAD `f531433`.

```julia
using ModelingToolkit, MultibodyComponents
import DyadCompilerPasses

@named model = MultibodyComponents.tests.WheelInWorld()
ssys = MultibodyComponents.multibody(model)   # ← Tearing internal error before this PR
```

Stack of the failing pre-PR error:

```
Tearing internal error: lowering DAE into semi-implicit ODE failed!
  [2] generate_system_equations!(...) @ ModelingToolkitTearing reassemble.jl:499
  [4] DefaultReassembleAlgorithm(...)  @ ModelingToolkitTearing reassemble.jl:1184
  [6] dummy_derivative                 @ ModelingToolkit symbolics_tearing.jl:84
 [19] multibody(model::System, ...)    @ MultibodyComponents
```

After this PR, `multibody(model)` completes; the sibling `SlipWheelInWorld` test (which already compiled) continues to compile and integrate to `t_end = 3.0` with `retcode = Success`.

## Regression test

Not included here. The bug only surfaces with the dummy-derivative alias pattern produced by the multibody port; minimal 2D rolling-disk MTK-only models (with and without acceleration-level kinetics) compile cleanly both with and without this fix, so they don't witness the bug. The rolling-wheel reproducer above is the smallest known trigger; happy to backport a regression test if a smaller MTK-only MWE is found.

## Test plan

- [x] `mtkcompile(MultibodyComponents.tests.WheelInWorld())` succeeds (previously threw `Tearing internal error`).
- [x] `MultibodyComponents.tests.SlipWheelInWorld` still compiles + integrates to `t_end = 3.0`, `retcode = Success`.
- [x] `Pkg.test("ModelingToolkitTearing")` shows the same 2 pre-existing `trivial_tearing!` failures with and without this change — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)