### PR TITLE
fix: clear buffers between SCCs in `CarpanzanoTearing`

### DIFF
--- a/src/carpanzano_tearing.jl
+++ b/src/carpanzano_tearing.jl
@@ -55,6 +55,8 @@ function (alg::CarpanzanoTearing)(structure::SystemStructure)
     active_vars = OrderedSet{Int}()
     active_eqs = OrderedSet{Int}()
     for vars in var_sccs
+        empty!(active_vars)
+        empty!(active_eqs)
         for var in vars
             # Identify variables and equations in this SCC
             if varfilter(var)


### PR DESCRIPTION
Proposed alternative fix for #82 

While trying to find where `full_var_eq_matching` could differ from `var_eq_matching` so egregiously as to match variables outside their SCC, I noticed this. `carpanzano_tear_scc!` runs for as long as `active_vars` contains variables. By the end of it, `active_eqs` may still have values. These would then get carried over to subsequent SCCs, causing problems.

Carpanzano marks variables as algebraic by simply removing them from `active_vars`. It never removes entries from `active_eqs` unless the equation was matched to a variable. So for algebraic SCCs, `active_eqs` will have leftover entries.