### PR TITLE
Bump FindFirstFunctions compat to allow 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ StateSelectionDeepDiffsExt = "DeepDiffs"
 [compat]
 BipartiteGraphs = "0.1.2"
 DocStringExtensions = "0.9.3"
-FindFirstFunctions = "1.2.0"
+FindFirstFunctions = "1.2.0, 2"
 Graphs = "1.10.0"
 LinearAlgebra = "1.10.0"
 OrderedCollections = "1"


### PR DESCRIPTION
## Summary

StateSelection currently pins `FindFirstFunctions = "1.2.0"`, which blocks downstream consumers from using FFF 2.0. The only FFF symbol used here is `findfirstequal` (in `src/math/sparsematrixclil.jl`), whose signature is unchanged between FFF 1.x and 2.0 — it remains `findfirstequal(vpivot, ivars) -> Union{Int, Nothing}`, with the same `DenseVector{Int64}` fast path.

This PR bumps the compat to `"1.2.0, 2"`.

## Why

FFF 2.0 added a new strategy-based API (`Auto`, `SearchProperties`, `searchsortedlast!` etc.) without breaking the equality API. Downstream packages that have moved to FFF 2.0 (e.g. SciML/DataInterpolations.jl#529) cannot co-resolve with StateSelection 1.x, which blocks any docs/test build that pulls in both via ModelingToolkit.

## Verification

- Cloned this repo, applied the compat bump, `dev`-installed FFF 2.0 from a local checkout.
- `Pkg.test()` passes cleanly on Julia 1.11 (`bareiss`, `carpanzano_tearing`, `get_new_mm` testsets — all 13 assertions green).
- No source changes needed; FFF 2.0 retains the same `findfirstequal` definition.

## Notes

Please ignore until reviewed by @ChrisRackauckas. Submitting from an external account; the change is mechanical and the test suite confirms compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)