### PR TITLE
fix: structural cheap_iszero hook in CLIL dropzeros! (OOM on symbolic values after #97)

### DIFF
--- a/lib/ModelingToolkitTearing/src/reassemble.jl
+++ b/lib/ModelingToolkitTearing/src/reassemble.jl
@@ -787,8 +787,11 @@ function __reduce_linear_system!(A::StateSelection.CLIL.SparseMatrixCLIL{Num, In
             cst += coeff * other_cst
         end
 
-        # `sparsevec` sums duplicate indices but keeps explicit zeros; drop them.
-        aliases[var] = SparseArrays.dropzeros!(SparseArrays.sparsevec(new_I, new_V, length(coeffs)))
+        # `sparsevec` sums duplicate indices but keeps explicit zeros. Drop them
+        # with a structural zero check
+        v = SparseArrays.sparsevec(new_I, new_V, N)
+        SparseArrays.fkeep!((_, x) -> !StateSelection.CLIL.cheap_iszero(x), v)
+        aliases[var] = v
         constants[var] = cst
     end
 

--- a/lib/ModelingToolkitTearing/src/stateselection_interface.jl
+++ b/lib/ModelingToolkitTearing/src/stateselection_interface.jl
@@ -105,6 +105,13 @@ function StateSelection.linear_subsys_adjmat!(state::TearingState; kwargs...)
     return mm
 end
 
+# Structural zero check for symbolic CLIL values: `Base.iszero(::Num)` performs
+# a semantic (expansion-based) zero test that can OOM on large coefficient
+# expressions (e.g. multibody models), while explicit stored zeros produced by
+# duplicate-index summation are always structural `Const(0)`.
+StateSelection.CLIL.cheap_iszero(x::Num) = SU._iszero(Symbolics.unwrap(x))
+StateSelection.CLIL.cheap_iszero(x::SymbolicT) = SU._iszero(x)
+
 function maybe_zeros_descend(ex::SymbolicT)
     @match ex begin
         BSImpl.AddMul(; variant) => return variant === SU.AddMulVariant.MUL

--- a/src/math/sparsematrixclil.jl
+++ b/src/math/sparsematrixclil.jl
@@ -91,6 +91,18 @@ zero!(a::SparseVector) = (empty!(a.nzind); empty!(a.nzval))
 zero!(a::CLILVector) = zero!(a.vec)
 SparseArrays.dropzeros!(a::CLILVector) = SparseArrays.dropzeros!(a.vec)
 
+"""
+    cheap_iszero(x)
+
+Structural zero check used by [`SparseArrays.dropzeros!`](@ref) on
+`SparseMatrixCLIL`. Defaults to `Base.iszero`. Downstream packages whose CLIL
+value type is symbolic should overload this with a cheap *structural* check:
+`Base.iszero` on e.g. `Symbolics.Num` performs a semantic (expansion-based)
+zero test that can be arbitrarily expensive on large expressions, while
+explicit stored zeros are always structural zeros.
+"""
+cheap_iszero(x) = iszero(x)
+
 # Remove explicitly-stored zeros from each row, in place.
 function SparseArrays.dropzeros!(S::SparseMatrixCLIL)
     for r in eachindex(S.row_vals)
@@ -98,7 +110,7 @@ function SparseArrays.dropzeros!(S::SparseMatrixCLIL)
         vals = S.row_vals[r]
         j = 0
         for k in eachindex(vals)
-            iszero(vals[k]) && continue
+            cheap_iszero(vals[k]) && continue
             j += 1
             cols[j] = cols[k]
             vals[j] = vals[k]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -345,7 +345,8 @@ function get_new_mm(
             # entry: a prior cancellation may have `pop!`ed the matching entry.
             if !isempty(final_row_cols) && col == final_row_cols[end]
                 final_row_vals[end] += new_row_val_i[indices[i]]
-                if iszero(final_row_vals[end])
+                # Structural zero check:
+                if CLIL.cheap_iszero(final_row_vals[end])
                     pop!(final_row_cols)
                     pop!(final_row_vals)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,16 @@ using Test
 include("bareiss.jl")
 include("carpanzano_tearing.jl")
 
+# A value type whose `Base.iszero` is "semantic" and must never be consulted by
+# `dropzeros!` — stands in for symbolic value types (e.g. `Symbolics.Num`),
+# where the semantic zero test is arbitrarily expensive. `dropzeros!` must go
+# through the `cheap_iszero` hook instead.
+struct SemanticZero
+    x::Int
+end
+Base.iszero(::SemanticZero) = error("semantic iszero must not be called by dropzeros!")
+SSel.CLIL.cheap_iszero(v::SemanticZero) = v.x == 0
+
 @testset "`get_new_mm`" begin
     mm = SSel.CLIL.SparseMatrixCLIL(
         [
@@ -71,4 +81,12 @@ include("carpanzano_tearing.jl")
     mm2 = SSel.get_new_mm(aliases, old_to_new_eq, old_to_new_var, mm)
     @test mm2.row_cols == [[2]]
     @test mm2.row_vals == [[1]]
+end
+
+@testset "`dropzeros!` uses the `cheap_iszero` hook" begin
+    mm = SSel.CLIL.SparseMatrixCLIL{SemanticZero, Int}(
+        1, 2, [1], [[1, 2]], [[SemanticZero(0), SemanticZero(3)]])
+    SparseArrays.dropzeros!(mm)
+    @test mm.row_cols == [[2]]
+    @test map(v -> v.x, only(mm.row_vals)) == [3]
 end


### PR DESCRIPTION
Follow-up to #97, implementing the fix proposed in [this comment](https://github.com/JuliaComputing/StateSelection.jl/pull/97#issuecomment-4673408844).

## Problem

`dropzeros!(::SparseMatrixCLIL)` (added in #97) calls `Base.iszero` on the stored values. In `get_new_mm` the value type is `Num`, and `iszero(::Num)` is a *semantic* zero test (`fraction_iszero` → `expand`) that can be arbitrarily expensive. On `MultibodyComponents.examples.suspension.HalfCar` the process is OOM-killed inside `dropzeros!` at ~row 40 of a 295-row `Num`-valued `mm` (instrumented run; the pre-#97 commit completes fine).

## Fix

Explicit stored zeros (as produced by `sparsevec` duplicate-index summation or alias cancellation) are always *structural* zeros, so a structural check suffices:

- `StateSelection.CLIL.cheap_iszero(x) = iszero(x)` — hook used by `dropzeros!(::SparseMatrixCLIL)` instead of `Base.iszero`,
- `ModelingToolkitTearing` overloads it for `Num`/`SymbolicT` via `SU._iszero` (structural `Const(0)` check, no expansion).

Numeric value types are unaffected (the default is `Base.iszero`).

## Validation

- New regression test: a value type whose `Base.iszero` throws (standing in for "arbitrarily expensive") must still round-trip through `dropzeros!` correctly via the hook.
- The equivalent patch was validated on the HalfCar model: compiles without OOM, with behavior otherwise identical to pre-#97 (same emitted inline-linsolve blocks; details in the [#97 comment](https://github.com/JuliaComputing/StateSelection.jl/pull/97#issuecomment-4673408844)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
