### PR TITLE
cut off stringifying large expressions in equation sorting 

### DIFF
--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -365,8 +365,12 @@ function TearingState(sys::System, source_info::Union{Nothing, MTKBase.EquationS
 
     if sort_eqs
         # sort equations lexicographically to reduce simplification issues
-        # depending on order due to NP-completeness of tearing.
-        sortidxs = Base.sortperm(string.(eqs)) # "by = string" creates more strings
+        # depending on order due to NP-completeness of tearing. Sort on a
+        # bounded prefix of the printed form: the full `string` of an equation
+        # is exponential in the sharing depth of hash-consed expressions, and
+        # ties on the first 4096 bytes keep their original (deterministic)
+        # relative order since the default sort is stable.
+        sortidxs = Base.sortperm(map(Base.Fix2(bounded_string, 4096), eqs))
         eqs = eqs[sortidxs]
         original_eqs = original_eqs[sortidxs]
         symbolic_incidence = symbolic_incidence[sortidxs]

--- a/lib/ModelingToolkitTearing/src/utils.jl
+++ b/lib/ModelingToolkitTearing/src/utils.jl
@@ -176,3 +176,63 @@ function permute(mm::StateSelection.SparseMatrixCLIL{S, T}, oldtonewvar::Vector{
 
     return StateSelection.SparseMatrixCLIL{S, T}(mm.nparentrows, mm.ncols, nzrows, rowcols, rowvals)
 end
+
+"""
+    $TYPEDEF
+
+Thrown by [`BoundedIO`](@ref) when the byte limit is reached.
+"""
+struct BoundedIOOverflow <: Exception end
+
+"""
+    $TYPEDEF
+
+An `IO` wrapper that throws [`BoundedIOOverflow`](@ref) once more than
+`remaining` bytes have been written to it. Printing a symbolic expression
+produces output proportional to its *tree* size, which is exponential in the
+sharing depth of the hash-consed DAG; since printing streams depth-first,
+aborting after a bounded number of bytes also bounds the traversal work.
+"""
+mutable struct BoundedIO{T <: IO} <: IO
+    io::T
+    remaining::Int
+end
+
+function Base.write(io::BoundedIO, b::UInt8)
+    io.remaining <= 0 && throw(BoundedIOOverflow())
+    io.remaining -= 1
+    return write(io.io, b)
+end
+
+# Without this, bulk writes (e.g. printing a `String`) fall back to Base's
+# generic byte-at-a-time `unsafe_write`. Mirror what `LimitIO` does: write the
+# whole chunk at once, filling exactly up to the limit before aborting.
+function Base.unsafe_write(io::BoundedIO, p::Ptr{UInt8}, nb::UInt)
+    if nb > io.remaining
+        if io.remaining > 0
+            unsafe_write(io.io, p, io.remaining % UInt)
+            io.remaining = 0
+        end
+        throw(BoundedIOOverflow())
+    end
+    nw = unsafe_write(io.io, p, nb)
+    io.remaining -= nw
+    return nw
+end
+
+"""
+    $TYPEDSIGNATURES
+
+`string(x)`, truncated to at most `limit` bytes of output. The truncation also
+bounds the printing work, making this safe to call on expressions whose full
+printed form would be astronomically large.
+"""
+function bounded_string(x, limit::Int)
+    buf = IOBuffer(; sizehint = limit)
+    try
+        print(BoundedIO(buf, limit), x)
+    catch err
+        err isa BoundedIOOverflow || rethrow()
+    end
+    return String(take!(buf))
+end


### PR DESCRIPTION
We can get stuck here if we get very large expressions, truncate to 4096 bytes (without forming the large string in the first place)

This is the same approach as the REPL uses (https://github.com/JuliaLang/julia/blob/master/stdlib/REPL/src/REPL.jl#L479-L522)

Ideally, we probably wouldn't form strings at all, but at least for now, I think this is an improvement.