### PR TITLE
refactor: respect tearing in inline linear SCCs

### DIFF
--- a/lib/ModelingToolkitTearing/src/reassemble.jl
+++ b/lib/ModelingToolkitTearing/src/reassemble.jl
@@ -740,7 +740,6 @@ function __reduce_linear_system!(A::StateSelection.CLIL.SparseMatrixCLIL{Num, In
     constants = Dict{Int, SymbolicT}()
     aliases = Dict{Int, SparseArrays.SparseVector{Num, Int}}()
     for (i, coeffs) in enumerate(A.row_vals)
-        all(SU.isconst ∘ unwrap, coeffs) || continue
         eq_var_matching[alg_eqs[i]] isa Int || continue
 
         eqs_mask[i] = false

--- a/lib/ModelingToolkitTearing/test/runtests.jl
+++ b/lib/ModelingToolkitTearing/test/runtests.jl
@@ -160,9 +160,9 @@ end
     @test length(blocks) == 1
     blk = only(blocks)
     @test blk isa InlineLinearSystem
-    @test blk.size == 3
+    @test blk.size == 2
     @test length(blk.variables) == blk.size
-    @test issetequal(blk.variables, [y, z, w])
+    @test issubset(blk.variables, Set([y, z, w]))
     # the retained expression is the solve term `A \ b`
     @test SU.operation(unwrap(blk.expression)) === MTKTearing.INLINE_LINEAR_SCC_OP
     @test length(SU.arguments(unwrap(blk.expression))) == 2


### PR DESCRIPTION
Previously this was disabled because it caused bugs in simplified models. However, we are in a much better place regarding model simplification now, so it might be possible to significantly reduce the size of linsolves in simplified models.