### PR TITLE
fix: `ClockVertex` `Expression` handling

### DIFF
--- a/lib/ModelingToolkitTearing/src/clock_inference/clock_inference.jl
+++ b/lib/ModelingToolkitTearing/src/clock_inference/clock_inference.jl
@@ -274,7 +274,9 @@ function (ivc::InferVariableClosure)(var::SymbolicT)
             nested_ivc(v)
         end
 
-        push!(arg_hyperedge, ClockVertex.Expression(arg))
+        if !SU.isconst(arg)
+            push!(arg_hyperedge, ClockVertex.Expression(arg))
+        end
         # NOTE: Ensure all branches here add `arg_hyperedge` to the inference graph. It
         # is the parent hyperedge for `nested_ivc`, so this closure is responsible for
         # adding it to the graph.


### PR DESCRIPTION
A `ClockVertex` `Expression` can be a constant; do not add such expressions to the hypergraph.