### PR TITLE
Fix inline-linear-SCC topsort cycle when chaining Euler orientation states (MTK#4608)

### DIFF
--- a/lib/ModelingToolkitTearing/src/reassemble.jl
+++ b/lib/ModelingToolkitTearing/src/reassemble.jl
@@ -622,10 +622,35 @@ function get_linear_scc_linsol(state::TearingState, alg_eqs::Vector{Int},
         b[eqidx] = resid
     end
 
+    # Per-equation incidence is read off the actual `total_sub`-substituted residual rather
+    # than the structural incidence `graph`. The `graph` is built before substitution and is
+    # mutated during reassembly, so it can desync from the residual once `total_sub`
+    # reintroduces an SCC variable (e.g. chaining rotation-matrix orientation states pulls a
+    # propagated angular velocity, hence the Euler-angle rate, into the residual of an
+    # equation whose structural edge was already torn). Gating extraction on the stale
+    # `graph` then skips expanding that variable into the coefficient matrix `A`, leaving it
+    # buried in `b`; it is subsequently smuggled onto the RHS by `__reduce_linear_system!`
+    # (which inspects only the coefficient row, never `b`), producing a self-referential
+    # `A \ b` whose observed equations cannot be topologically ordered
+    # (SciML/ModelingToolkit.jl#4608, issue #98). Gating on the residual's real incidence
+    # expands every present SCC variable into `A`, keeping `b` free of SCC variables by
+    # construction.
+    resid_atoms = Vector{Set{SymbolicT}}(undef, length(b))
+    for eqidx in eachindex(b)
+        s = Set{SymbolicT}()
+        Symbolics.get_variables!(s, b[eqidx])
+        resid_atoms[eqidx] = s
+    end
     for (varidx, var) in enumerate(vars)
+        var_atoms = Set{SymbolicT}()
+        Symbolics.get_variables!(var_atoms, var)
         lex = MTKBase.get_linear_expander_for!(sys, var, true)
         for (eqidx, resid) in enumerate(b)
-            Graphs.has_edge(graph, BipartiteEdge(alg_eqs[eqidx], alg_vars[varidx])) || continue
+            # Skip only when the SCC variable is genuinely absent from this residual. The
+            # residual is mutated to `q` (the remainder after extraction) below; since
+            # extraction never introduces new variables into `q`, the pre-loop `resid_atoms`
+            # snapshot is a sound (tight) over-approximation of what is still present.
+            isdisjoint(var_atoms, resid_atoms[eqidx]) && continue
             p, q, islinear = lex(resid)
             islinear || return nothing
             if !SU._iszero(p)
@@ -637,13 +662,9 @@ function get_linear_scc_linsol(state::TearingState, alg_eqs::Vector{Int},
         end
     end
 
-    # The `has_edge` gate above relies on the structural incidence `graph`, which is mutated
-    # during reassembly and could in principle desync from the `total_sub`-substituted
-    # residual, leaving a live SCC variable buried inside some `b[eqidx]`. Such a variable
-    # would be smuggled onto the RHS of retained equations by `__reduce_linear_system!`
-    # (which inspects only the coefficient row, never `b`), producing an inconsistent runtime
-    # `A \ b` (issue #98). The construction is expected to keep `b` free of all SCC
-    # variables; when the self-check is enabled, assert it so any regression surfaces loudly.
+    # With residual-incidence gating above, `b` is free of all SCC variables by
+    # construction. The opt-in self-check asserts this invariant so any regression
+    # (e.g. a future change reintroducing structural-graph gating) surfaces loudly.
     _inline_scc_check_enabled() && _assert_b_free_of_scc_vars(b, vars)
 
     # `-` is important! `b` is on the other side of the equality.


### PR DESCRIPTION
## Summary
Fixes the `mtkcompile`/`structural_simplify` failure `ArgumentError: The equations have at least one cycle.` (from `topsort_equations`) when chaining two or more rotation-matrix (Euler) orientation states — **SciML/ModelingToolkit.jl#4608**.

Stacks on #106, which adds the opt-in `_assert_b_free_of_scc_vars` invariant. This PR makes that invariant hold **by construction** (and thus actually fixes #4608), rather than only checking it under `MTKTEARING_CHECK_REDUCTION`.

## Root cause
`get_linear_scc_linsol` builds the inline `A \ b` block by extracting each SCC variable's coefficient out of every (`total_sub`-substituted) residual, gated on the **structural incidence graph** via `has_edge(graph, eq, var)`. That graph is built *before* `total_sub` substitution and is mutated during reassembly, so it can **desync** from the residual: `total_sub` can reintroduce an SCC variable into a residual whose structural edge was already torn. The `has_edge` gate then skips expanding that variable into the coefficient matrix `A`, leaving it buried in `b`. `__reduce_linear_system!` — which only inspects coefficient rows, never `b` — subsequently smuggles it onto the RHS, producing a self-referential `A \ b` (the solution vector appears inside its own RHS). The resulting observed equations form a cycle that `topsort_equations` rejects.

Confirmed on the #4608 MWE: the buried variables are exactly the **second** joint's Euler rates `j2.phid[1:3]`, all with `has_edge == false`. The world-rooted first joint stays in sync (constant `R`, zero angular velocity), which is why a single Euler joint compiles but two chained do not.

## Fix
Gate extraction on the **actual residual incidence** (`get_variables` on the substituted residual) instead of the stale structural graph. Every SCC variable genuinely present in a residual is expanded into `A`, so `b` is free of SCC variables by construction. Blocks whose structural graph is already in sync get identical extraction and identical output — no behavior change on healthy models.

## Verification (registry MTK 11.26.8)
A/B over models that expose the cycle and controls that do not:

| Model | before | after |
|---|---|---|
| 1 Euler `Spherical` (control) | compiles (6) | compiles (6) |
| **2 chained Euler `Spherical`** | **cycle** | **compiles (15), 0 self-ref obs** |
| **3 chained Euler `Spherical`** | **cycle** | **compiles (18), 0 self-ref obs** |
| 2 chained Quaternion (control) | compiles (17) | compiles (17) |
| **`Cable`, 3 Euler segments** | **cycle** | **compiles (24), 0 self-ref obs** |
| **`Cable`, 5 Euler segments** | **cycle** | **compiles (36), 0 self-ref obs** |
| `Cable`, 3 Quaternion (control) | compiles (28) | compiles (28) |

All controls keep identical unknown counts → no regression. With `MTKTEARING_CHECK_REDUCTION=1` the `#106` self-check confirms the previously self-referential `j2.phid` block is now consistent (relres ≈ 4e-17).

## Scope
Draft. This fixes the structural cycle only. Runtime *solving* of these models hits a separate, non-rank-tolerant inline-`\` (LU) issue at degenerate configurations — independent of the cycle and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
