### PR TITLE
feat: allow storing `mm` in `TearingState`

### DIFF
--- a/lib/ModelingToolkitTearing/src/stateselection_interface.jl
+++ b/lib/ModelingToolkitTearing/src/stateselection_interface.jl
@@ -7,13 +7,73 @@ function StateSelection.var_derivative!(ts::TearingState, v::Int)
     push!(ts.structure.state_priorities, ts.structure.state_priorities[v])
     push!(ts.structure.var_types, ts.structure.var_types[v])
     push!(ts.always_present, ts.always_present[v])
+    mm = ts.mm
+    if mm !== nothing
+        @set! mm.ncols += 1
+        ts.mm = mm
+    end
     return var_diff
+end
+
+function eq_derivative_mm!(ts::TearingState, ieq::Int, eq_diff::Int, idx::Int)
+    s = ts.structure
+    mm = ts.mm::CLIL.SparseMatrixCLIL{Int, Int}
+    eqs = equations(ts)
+
+    rcol = copy(mm.row_cols[idx])
+    rval = mm.row_vals[idx]
+    # Differentiate the variables involved
+    map!(Base.Fix1(getindex, s.var_to_diff), rcol, rcol)
+    # Add to `mm`
+    @assert eq_diff > last(mm.nzrows)
+    push!(mm.nzrows, eq_diff)
+    push!(mm.row_cols, rcol)
+    push!(mm.row_vals, rval)
+
+    # Rebuild the RHS. We know what structure this will take, so can again
+    # use a custom fast path.
+    add_dict = SU.ACDict{VartypeT}()
+    sizehint!(add_dict, length(rcol))
+    T = SU.promote_symtype(*, Int, SU.symtype(ts.fullvars[rcol[1]]))
+    for (iv, coeff) in zip(rcol, rval)
+        var = ts.fullvars[iv]
+        _T = SU.promote_symtype(*, Int, SU.symtype(var))
+        T = SU.promote_symtype(+, T, _T)
+        add_dict[var] = coeff
+    end
+    rhs = BSImpl.AddMul{VartypeT}(0, add_dict, SU.AddMulVariant.ADD; type = T, shape = SU.ShapeVecT())
+    eq = Symbolics.COMMON_ZERO ~ rhs
+    push!(eqs, eq)
+
+    @assert length(equations(ts)) == eq_diff
+
+    for v in rcol
+        add_edge!(s.graph, eq_diff, v)
+        if s.solvable_graph !== nothing
+            add_edge!(s.solvable_graph, eq_diff, v)
+        end
+    end
+
+    return eq_diff
 end
 
 function StateSelection.eq_derivative!(ts::TearingState, ieq::Int; kwargs...)
     s = ts.structure
 
     eq_diff = StateSelection.eq_derivative_graph!(s, ieq)
+
+    mm = ts.mm
+    if mm !== nothing
+        # Regardless of what we do, an additional equation is added to the system
+        @set! mm.nparentrows += 1
+        # Remember to set back into `ts`
+        ts.mm = mm
+
+        # Fast path. If we have `mm`, and the equation we're differentiating is present
+        # in `mm`, differentation is trivial.
+        idxs = searchsorted(mm.nzrows, ieq)
+        isempty(idxs) || return eq_derivative_mm!(ts, ieq, eq_diff, first(idxs))
+    end
 
     sys = ts.sys
     eqs = equations(ts)
@@ -51,10 +111,21 @@ function StateSelection.eq_derivative!(ts::TearingState, ieq::Int; kwargs...)
     # We already ran `search_variables!`, so we can identify the ones that
     # really need to be removed here.
     to_rm = Int[]
-    s.solvable_graph === nothing || StateSelection.find_eq_solvables!(
-        ts, eq_diff, to_rm; may_be_zero = true, allow_symbolic = false,
-        symbolically_rm_singular = false, kwargs...
-    )
+    coeffs = Int[]
+    solvable_graph = s.solvable_graph
+    if solvable_graph !== nothing
+        all_int_vars, rhs = StateSelection.find_eq_solvables!(
+            ts, eq_diff, to_rm, coeffs; may_be_zero = true, allow_symbolic = false,
+            symbolically_rm_singular = false, kwargs...
+        )
+        # Update `mm` if possible
+        if mm !== nothing && all_int_vars && SU._iszero(rhs)
+            @assert isempty(mm.nzrows) || eq_diff > last(mm.nzrows)
+            push!(mm.nzrows, eq_diff)
+            push!(mm.row_cols, copy(𝑠neighbors(solvable_graph, eq_diff)))
+            push!(mm.row_vals, coeffs)
+        end
+    end
 
     for i in to_rm
         ts.fullvars[i] in vs || continue

--- a/lib/ModelingToolkitTearing/src/stateselection_interface.jl
+++ b/lib/ModelingToolkitTearing/src/stateselection_interface.jl
@@ -5,6 +5,7 @@ function StateSelection.var_derivative!(ts::TearingState, v::Int)
     D = Differential(MTKBase.get_iv(sys))
     push!(ts.fullvars, D(ts.fullvars[v]))
     push!(ts.structure.state_priorities, ts.structure.state_priorities[v])
+    push!(ts.structure.canonical_ranks, ts.structure.canonical_ranks[v] + 1)
     push!(ts.structure.var_types, ts.structure.var_types[v])
     push!(ts.always_present, ts.always_present[v])
     mm = ts.mm

--- a/lib/ModelingToolkitTearing/src/stateselection_interface.jl
+++ b/lib/ModelingToolkitTearing/src/stateselection_interface.jl
@@ -129,7 +129,8 @@ function StateSelection.eq_derivative!(ts::TearingState, ieq::Int; kwargs...)
 
     for i in to_rm
         ts.fullvars[i] in vs || continue
-        a, b, islin = Symbolics.linear_expansion(eqs[eq_diff].rhs, ts.fullvars[i])
+        lex = MTKBase.get_linear_expander_for!(sys, ts.fullvars[i], true)
+        a, b, islin = lex(eqs[eq_diff].rhs)
         @assert islin && SU._iszero(a)
         eqs[eq_diff] = Symbolics.COMMON_ZERO ~ b
     end

--- a/lib/ModelingToolkitTearing/src/stateselection_interface.jl
+++ b/lib/ModelingToolkitTearing/src/stateselection_interface.jl
@@ -433,11 +433,14 @@ function StateSelection.rm_eqs_vars!(
     old_to_new_eq, old_to_new_var = StateSelection.default_rm_eqs_vars!(
         structure, eqs_to_rm, vars_to_rm; eqs_sorted_and_uniqued, vars_sorted_and_uniqued
     )
+    deleteat!(structure.canonical_ranks, vars_to_rm)
     deleteat!(structure.state_priorities, vars_to_rm)
     deleteat!(structure.var_types, vars_to_rm)
     return old_to_new_eq, old_to_new_var
 end
 
+# This does NOT update `state.mm` since it doesn't have `aliases` information. That is
+# the responsibility of the caller using `get_new_mm`.
 function StateSelection.rm_eqs_vars!(
         state::TearingState, eqs_to_rm::Vector{Int}, vars_to_rm::Vector{Int};
         eqs_sorted_and_uniqued::Bool = false, vars_sorted_and_uniqued::Bool = false

--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -527,10 +527,11 @@ end
     $TYPEDSIGNATURES
 
 Rank of each variable in `fullvars` under the [`canonical_sort_key`](@ref) order.
-Used as a deterministic tie-break (after priorities) in tearing.
+Used as a deterministic tie-break (after priorities) in tearing. Ranks are multiplied
+by a constant factor to enable inserting new variables in between.
 """
 function build_canonical_ranks(fullvars::Vector{SymbolicT})
-    return invperm(sortperm(map(canonical_sort_key, fullvars)))
+    return invperm(sortperm(map(canonical_sort_key, fullvars))) .* 100
 end
 
 function build_state_priorities(sys::System, fullvars::Vector{SymbolicT}, var_to_diff::StateSelection.DiffGraph)

--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -91,6 +91,11 @@ mutable struct TearingState <: StateSelection.TransformationState{System}
     or source information is unknown.
     """
     eqs_source::Vector{Vector{Symbol}}
+    """
+    A `SparseMatrixCLIL` identifying equations which are integer-coefficient linear
+    combinations of variables.
+    """
+    mm::Union{Nothing, CLIL.SparseMatrixCLIL{Int, Int}}
 end
 
 function Base.show(io::IO, state::TearingState)
@@ -434,7 +439,7 @@ function TearingState(sys::System, source_info::Union{Nothing, MTKBase.EquationS
                                 canonical_ranks, false)
     return TearingState(sys, fullvars, structure, Equation[], param_derivative_map,
                         no_deriv_params, original_eqs, Equation[], falses(length(fullvars)),
-                        typeof(sys)[], sources)
+                        typeof(sys)[], sources, nothing)
 end
 
 """

--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -1,3 +1,10 @@
+# NOTE: Checklist for adding new fields to `SystemStructure` or `TearingState`
+# - Is it populated in the `TearingState` constructor?
+# - Is it handled in the `copy` method?
+# - Is it updated in `var_derivative!`? (if necessary)
+# - Is it updated in `eq_derivative!`? (if necessary)
+# - Is it updated in `rm_eqs_vars!`? (if necessary)
+
 """
     $TYPEDEF
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -190,7 +190,7 @@ function get_old_to_new_idxs(n_before::Int, dels::Vector{Int})
     for i in eachindex(old_to_new)
         if cursor <= ndels && i == dels[cursor]
             cursor += 1
-            old_to_new[i] = -1
+            old_to_new[i] = 0
             continue
         end
         idx += 1

--- a/src/singularity_removal.jl
+++ b/src/singularity_removal.jl
@@ -266,22 +266,9 @@ function aag_bareiss!(structure, mm_orig::SparseMatrixCLIL{T, Ti}) where {T, Ti}
     solvable_variables = findall(is_linear_variables)
     var_priorities = has_state_priorities(structure) ? get_state_priorities(structure) : nothing
 
-    local bar
-    try
-        bar = do_bareiss!(mm, mm_orig, is_linear_variables, is_highest_diff, var_priorities)
-    catch e
-        e isa OverflowError || rethrow(e)
-        mm = convert(SparseMatrixCLIL{BigInt, Ti}, mm_orig)
-        bar = do_bareiss!(mm, mm_orig, is_linear_variables, is_highest_diff, var_priorities)
-    end
+    bar = do_bareiss!(mm, mm_orig, is_linear_variables, is_highest_diff, var_priorities)
 
-    # This phrasing infers the return type as `Union{Tuple{...}}` instead of
-    # `Tuple{Union{...}, ...}`
-    if mm isa SparseMatrixCLIL{BigInt, Ti}
-        return mm, solvable_variables, bar
-    else
-        return mm, solvable_variables, bar
-    end
+    return mm, solvable_variables, bar
 end
 
 "Column-swap no-op passed to `bareiss!` when using the virtual column-swap strategy."

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,7 +298,6 @@ function get_new_mm(
         mm::CLIL.SparseMatrixCLIL
     )
 
-    new_nparentrows = mm.nparentrows
     new_row_cols = eltype(mm.row_cols)[]
     new_row_vals = eltype(mm.row_vals)[]
     new_nzrows = Int[]
@@ -362,7 +361,7 @@ function get_new_mm(
 
     # Drop explicit zeros (e.g. from an alias that cancelled to zero) so they
     # don't survive as phantom structural nonzeros.
-    new_mm = typeof(mm)(new_nparentrows, count(!iszero, old_to_new_var), new_nzrows, new_row_cols, new_row_vals)
+    new_mm = typeof(mm)(count(!iszero, old_to_new_eq), count(!iszero, old_to_new_var), new_nzrows, new_row_cols, new_row_vals)
     return SparseArrays.dropzeros!(new_mm)
 end
 


### PR DESCRIPTION
This fixes issues where `mm` is invalidated by operations in Pantelides/dummy derivatives and is subsequently relied on in reassembly. Fully leveraging this PR requires MTK to populate the new field.