### PR TITLE
Allow FindFirstFunctions v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StateSelection"
 uuid = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
 authors = ["JuliaHub", "Inc. and other contributors"]
-version = "1.10.2"
+version = "1.10.3"
 
 [deps]
 BipartiteGraphs = "caf10ac8-0290-4205-88aa-f15908547e8d"
@@ -22,7 +22,7 @@ StateSelectionDeepDiffsExt = "DeepDiffs"
 [compat]
 BipartiteGraphs = "0.1.2"
 DocStringExtensions = "0.9.3"
-FindFirstFunctions = "1.2.0, 2"
+FindFirstFunctions = "1.2.0, 2, 3"
 Graphs = "1.10.0"
 LinearAlgebra = "1.10.0"
 OrderedCollections = "1"


### PR DESCRIPTION
StateSelection imports a single name from FindFirstFunctions — `findfirstequal` — which is unchanged in v3, but the compat entry (`"1.2.0, 2"`) predates the v3 release and excludes it. This blocks co-installation with packages requiring FindFirstFunctions 3 (e.g. DataInterpolations 9, and SciML/OrdinaryDiffEq.jl#3826 whose sublibrary CI fails on exactly this resolver conflict through the ModelingToolkit → StateSelection edge).

One-line compat widen + patch bump (1.10.2 → 1.10.3). Test suite verified locally with FindFirstFunctions pinned to 3.0.1: all passing.

Opened on behalf of @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uzZhKZV2ameiUL8ouYknd