### PR TITLE
refactor: scalarize initialization equations in `mtkcompile`

### DIFF
--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -176,6 +176,8 @@ function TearingState(sys::System, source_info::Union{Nothing, MTKBase.EquationS
             end
         end
     end
+    init_eqs = MTKBase.flatten_equations(initialization_equations(sys))
+    @set! sys.initialization_eqs = init_eqs
     original_eqs = copy(eqs)
     neqs = length(eqs)
     param_derivative_map = Dict{SymbolicT, SymbolicT}()

--- a/lib/ModelingToolkitTearing/test/runtests.jl
+++ b/lib/ModelingToolkitTearing/test/runtests.jl
@@ -361,3 +361,9 @@ end
     # This used to run `(-2) ^ 0.5` which hit a `DomainError`
     @test_nowarn mtkcompile(sys)
 end
+
+@testset "Initialization equations are scalarized in `mtkcompile`" begin
+    @variables x(t)[1:2]
+    @mtkcompile sys = System([D(x) ~ x], t; initialization_eqs = [x.^2 ~ 2ones(2)])
+    @test issetequal(initialization_equations(sys), [x[1]^2 ~ 2, x[2]^2 ~ 2])
+end


### PR DESCRIPTION
This ensures consistency with how normal equations are treated