### PR TITLE
Allow deferring scalarization of the init eqs also

### DIFF
--- a/lib/ModelingToolkitTearing/src/tearingstate.jl
+++ b/lib/ModelingToolkitTearing/src/tearingstate.jl
@@ -188,10 +188,10 @@ function TearingState(sys::System, source_info::Union{Nothing, MTKBase.EquationS
             end
         end
         eqs = MTKBase.flatten_equations(equations(sys))
+        init_eqs = MTKBase.flatten_equations(initialization_equations(sys))
+        @set! sys.initialization_eqs = init_eqs
     end
     any_array_eqs = false
-    init_eqs = MTKBase.flatten_equations(initialization_equations(sys))
-    @set! sys.initialization_eqs = init_eqs
     original_eqs = copy(eqs)
     neqs = length(eqs)
     param_derivative_map = Dict{SymbolicT, SymbolicT}()


### PR DESCRIPTION
Follow-on to #137: choosing to defer scalarization should apply to the initialization equations as well.